### PR TITLE
added keepRecommended option

### DIFF
--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -13,6 +13,8 @@
 #'   defaults to \code{packages.csv}. If it is NULL,
 #'   to output file is created and the result is returned
 #'   as a data frame.
+#' @param recommended if TRUE then recommended packages
+#' will be included in the snapshot.
 #' @return A two columns data frame, invisibly if it was
 #'   written to a file.
 #'
@@ -23,8 +25,11 @@
 #'
 #' head(read.csv(tmp))
 
-snap <- function(to = "packages.csv") {
-  pkgs <- installed.packages(priority = NA_character_)
+snap <- function(to = "packages.csv", recommended = FALSE) {
+  
+  priority <- if (recommended) "recommended" else c( "recommended", NA_character_)
+  
+  pkgs <- installed.packages(priority = priority)
   pkgs <- pkgs[, c("Package", "Version"), drop = FALSE]
   rownames(pkgs) <- NULL
   pkgs <- as.data.frame(pkgs, stringsAsFactors = FALSE)


### PR DESCRIPTION
Core and recommended are ignored. It would be useful to optionally include recommended. If your R installation is just r-core then `restore` will fail for dependencies such as lattice.

Another way to do it would be to pass through the priority option to installed.packages(). I don't really mind as long as there's a way to override the default.
