### PR TITLE
Deals with .zip files and fixes bug for unknown packages

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -35,7 +35,7 @@ get_description <- function(package_file) {
         exdir = tmp)
  } else {
   untar(package_file,
-        files = file.path(pkg, sep = "/", "DESCRIPTION"),
+        files = paste(pkg, sep = "/", "DESCRIPTION"),
         exdir = tmp)
  }
  

--- a/R/deps.R
+++ b/R/deps.R
@@ -23,20 +23,24 @@ hard_dep_types <- c("Imports", "Depends", "LinkingTo")
 #' @importFrom utils untar
 
 get_description <- function(package_file) {
-
-  pkg <- pkg_from_filename(package_file)
-
-  tmp <- tempfile()
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
-
-  untar(
-    package_file,
-    files = paste(pkg, sep = "/", "DESCRIPTION"),
-    exdir = tmp
-  )
-
-  desc_file <- file.path(tmp, pkg, "DESCRIPTION")
-  as.list(read.dcf(desc_file)[1, ])
+ 
+ pkg <- pkg_from_filename(package_file)
+ 
+ tmp <- tempfile()
+ on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+ 
+ if (tools::file_ext(package_file) == "zip") {
+  unzip(package_file,
+        files = paste(pkg, sep = "/", "DESCRIPTION"),
+        exdir = tmp)
+ } else {
+  untar(package_file,
+        files = file.path(pkg, sep = "/", "DESCRIPTION"),
+        exdir = tmp)
+ }
+ 
+ desc_file <- file.path(tmp, pkg, "DESCRIPTION")
+ as.list(read.dcf(desc_file)[1, ])
 }
 
 #' Extract (hard) package dependencies from an R package tarball
@@ -54,6 +58,7 @@ get_description <- function(package_file) {
 get_deps <- function(package_file) {
 
   desc <- get_description(package_file)
+
   deps_present<- intersect(hard_dep_types, names(desc))
 
   deps <- desc[deps_present]

--- a/R/restore.R
+++ b/R/restore.R
@@ -32,9 +32,11 @@ restore <- function(from = "packages.csv", R = TRUE, ...) {
 
   ## Download and return the downloaded file names
   pkg_files <- pkg_download(pkgs, dest_dir = tempdir())
+ 
+  pkg_files <- drop_invalid_path(pkg_files)
 
   deps <- lapply(pkg_files, get_deps)
-
+  
   deps <- drop_missing_deps(deps)
 
   order <- install_order(deps)
@@ -146,4 +148,15 @@ check_R_core <- function(pkgs, R) {
   }
   
   pkgs
+}
+
+#' Drop packages with invalid destination
+#'
+#' @param pkg_files A named list of character vectors.
+#' @return A named character vector without NA destination files.
+#'
+#' @keywords internal
+
+drop_invalid_path <- function(pkg_files) {
+ pkg_files <- pkg_files[!is.na(pkg_files), drop = FALSE]
 }

--- a/R/restore.R
+++ b/R/restore.R
@@ -29,6 +29,9 @@ restore <- function(from = "packages.csv", R = TRUE, ...) {
   
   # Remove this package (pkgsnap) from the list
   pkgs <- pkgs[pkgs$Package!="pkgsnap", ]
+  
+  # Remove packages with NA as source
+  pkgs <- pkgs[!is.na(pkgs$Source), ]
 
   ## Download and return the downloaded file names
   pkg_files <- pkg_download(pkgs, dest_dir = tempdir())

--- a/R/restore.R
+++ b/R/restore.R
@@ -27,9 +27,6 @@ restore <- function(from = "packages.csv", R = TRUE, ...) {
   # Check the R version and remove from the list
   pkgs <- check_R_core(pkgs, R)
   
-  # Remove this package (pkgsnap) from the list
-  pkgs <- pkgs[pkgs$Package!="pkgsnap", ]
-  
   # Remove packages with NA as source
   pkgs <- pkgs[!is.na(pkgs$Source), ]
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -27,8 +27,8 @@ restore <- function(from = "packages.csv", R = TRUE, ...) {
   # Check the R version and remove from the list
   pkgs <- check_R_core(pkgs, R)
   
-  # Remove packages with NA as source
-  pkgs <- pkgs[!is.na(pkgs$Source), ]
+  # Remove this package (pkgsnap) from the list
+  pkgs <- pkgs[pkgs$Package!="pkgsnap", ]
 
   ## Download and return the downloaded file names
   pkg_files <- pkg_download(pkgs, dest_dir = tempdir())

--- a/R/urls.R
+++ b/R/urls.R
@@ -110,7 +110,10 @@ download_urls <- function(pkgs) {
 
   lapply(seq_len(nrow(pkgs)), function(i) {
 
-    if (pkgs$Source[i] == "cran") {
+    if (is.na(pkgs$Source[i])) {
+      warning("Unknown package source: ", pkgs$repo[i])
+     
+    } else if (pkgs$Source[i] == "cran") {
       cran_file(pkgs$Package[i], pkgs$Version[i])
 
     } else if (pkgs$Source[i] == "bioc") {

--- a/R/urls.R
+++ b/R/urls.R
@@ -112,6 +112,7 @@ download_urls <- function(pkgs) {
 
     if (is.na(pkgs$Source[i])) {
       warning("Unknown package source: ", pkgs$repo[i])
+      character()
      
     } else if (pkgs$Source[i] == "cran") {
       cran_file(pkgs$Package[i], pkgs$Version[i])

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,3 +1,8 @@
+# 1.0.1
+ 
+## Bugfixes
+
+- Skip packages with NA as source (@ManuelaAlmeida)
 
 # 1.0.0
 


### PR DESCRIPTION
Hi, again!

I was having some troubles when the urls were .zip files. The error was on `untar` command, something I could reproduce on a simple .zip file:

```
untar("../snapshots/snapshot.zip")
Error in rawToChar(block[seq_len(ns)]) : 
  embedded nul in string: 'PK\003\004\024\0\0\0\b\0·}\037I·\0351È\003\0\0Á\020\0\0\f\0\0\0snapshot.csvÝWKÓ0\020¾#ñ'z¦Qœ6\r{dy\b\020\005T\036âê&&1qì`»Ý–_Ï8“ì’I\021T* qi-\177\035Ï{¾éì-'
```

So I added a fix for this (on `get_description` function).

I also had some problems when I included packages with unknown sources. The error was:

```
In file(con, "rb") : cannot open file 'NA': No such file or directory
```

So I removed the NA paths after creating the directories on `pkg_download`.

(Another small bugfix was adding `character()` after the warning when checking for NA as source)
