### PR TITLE
get configured CRAN mirror

### DIFF
--- a/R/urls.R
+++ b/R/urls.R
@@ -1,11 +1,25 @@
 
-#' CRAN mirror to use
+#' Default CRAN mirror to use
 #'
 #' The RStudio mirror is in the Amazon cloud, so most times it has
 #' the best response times, and download speed.
 #' @keywords internal
 
 default_cran_mirror <- "http://cran.rstudio.com"
+
+#' CRAN mirror to use
+#' 
+#' If a CRAN mirror is configured, use it. Otherwise, use default
+#' @keywords internal
+
+get_CRAN_mirror <- function() {
+  repos <- getOption("repos")
+  if (!("CRAN" %in% names(repos)) || "@CRAN@" %in% repos) {
+    message("No CRAN repository configured. Using default for pkgsnap: ", default_cran_mirror)
+    return(default_cran_mirror)
+  }
+  repos[["CRAN"]]
+}
 
 #' Extract the minor version of the running R
 #'
@@ -35,14 +49,16 @@ get_pkg_type <- function() {
 #' @param type Package type, e.g. \code{binary}, \code{source}, etc.
 #'   See the \code{type} argument of \code{utils::install.packages}.
 #' @param r_minor The minor R version to search for packages for.
-#'   Defaults to the currently running R version.
+#' @param cran_mirror The mirror to use for CRAN packages. Use 
+#'   \code{\link{default_cran_mirror}} if not configured in 
+#'   \code{getOption("repos")} 
 #' @return Character vector or URLs.
 #'
 #' @keywords internal
 
 cran_file <- function(package, version, type = get_pkg_type(),
                       r_minor = r_minor_version(),
-                      cran_mirror = default_cran_mirror) {
+                      cran_mirror = get_CRAN_mirror()) {
 
   if (type == "both") {
     c(cran_file(package, version, type = "binary", r_minor = r_minor, cran_mirror = cran_mirror),

--- a/R/urls.R
+++ b/R/urls.R
@@ -14,11 +14,13 @@ default_cran_mirror <- "http://cran.rstudio.com"
 
 get_cran_mirror <- function() {
   repos <- getOption("repos")
-  if (!("CRAN" %in% names(repos)) || "@CRAN@" %in% repos) {
-    message("No CRAN repository configured. Using default for pkgsnap: ", default_cran_mirror)
-    return(default_cran_mirror)
+  cran_mirror <- if (!("CRAN" %in% names(repos)) || "@CRAN@" %in% repos) {
+    default_cran_mirror
+  } else {
+    repos[["CRAN"]]
   }
-  repos[["CRAN"]]
+  message(sprintf("Using CRAN mirror %s.", cran_mirror))
+  cran_mirror
 }
 
 #' Extract the minor version of the running R

--- a/R/urls.R
+++ b/R/urls.R
@@ -12,7 +12,7 @@ default_cran_mirror <- "http://cran.rstudio.com"
 #' If a CRAN mirror is configured, use it. Otherwise, use default
 #' @keywords internal
 
-get_CRAN_mirror <- function() {
+get_cran_mirror <- function() {
   repos <- getOption("repos")
   if (!("CRAN" %in% names(repos)) || "@CRAN@" %in% repos) {
     message("No CRAN repository configured. Using default for pkgsnap: ", default_cran_mirror)
@@ -58,7 +58,7 @@ get_pkg_type <- function() {
 
 cran_file <- function(package, version, type = get_pkg_type(),
                       r_minor = r_minor_version(),
-                      cran_mirror = get_CRAN_mirror()) {
+                      cran_mirror = get_cran_mirror()) {
 
   if (type == "both") {
     c(cran_file(package, version, type = "binary", r_minor = r_minor, cran_mirror = cran_mirror),


### PR DESCRIPTION
This PR just allows to check if a CRAN mirror is set on the session before using default CRAN mirror of pkgsnap otherwise.

I hesitate to put the `cran_mirror` args in restore to allow user to set it manually. However, as he can change is _repos_ options manually. 

So I think it is fine. 

As said in the issue post, tests are not working but not due these changes I think. 